### PR TITLE
added templates to poll-channels module

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -1,7 +1,11 @@
 channels:
 
-  - name:                           # str  - user-friendly channel's name
-    channel_id:                     # str  - channel's link or username 
-    polling_interval:               # int  - how often poll the channel
-    message_limit:                  # int  - max number of messages to retrieve
-    private:                        # bool - show channel in public list or now
+  - name:                 # friendly name for channel
+    channel_id:           # url for channel
+    polling_interval:     # how often to poll channel
+    message_limit:        # how much messages returns
+    template:             # template dict describe list of regex, each regex is matched against appropriate line
+      - "^.*$"            # so 1st regex is matched against 1st line of message, 2nd regex against 2nd line, etc.
+      - "[^\/-]+"         # if message lines is less than regex amount then should return empty list for matches
+    tags:                 # dict of custom tags
+      private: false      # private tag is responsible to determine whether to show channel in public list or not


### PR DESCRIPTION
soo, poll channels module is now able to use regex templating instead of using python function to parse message.
Python function for parsing is the most functional solution that suits for any kind of messages.

However it's quite complicated and not recommended for end-user usage. As an example, to add one more template for specific telegram channel you've to write additional code. 

now you can specify template option in config to specify a list of regexes that would be matched line by line, so:
1st regex in template - against 1st line in message
2nd regex - against 2nd message line
3rd regex - against 3rd message line
etc.
Finally each regex should returns a list of matches. So for every one line you have 0, 1 or more matches returned by regex.

Despite of the limitation of this approach I found it easy to understand and use for end-user. 